### PR TITLE
chore: add defer injection for PWA register script

### DIFF
--- a/vite-plugins/pwa.ts
+++ b/vite-plugins/pwa.ts
@@ -5,6 +5,7 @@ import { displayName, description } from "../package.json";
 const pwa = () =>
   VitePWA({
     registerType: "autoUpdate",
+    injectRegister: "script-defer",
     manifestFilename: "manifest.webmanifest",
     manifest: {
       id: "/",


### PR DESCRIPTION
## Summary

- Set `injectRegister: "script-defer"` in `vite-plugins/pwa.ts` so the PWA register script is injected with `defer`