### PR TITLE
refactor: move hardcoded URLs to environment variables

### DIFF
--- a/env.config.ts
+++ b/env.config.ts
@@ -11,3 +11,8 @@ export const audioUrls: EnvironmentConfig<string> = {
   development: "https://englitune-audio.silvioprog.dev", // We don't have an audio server for development
   production: "https://englitune-audio.silvioprog.dev"
 } as const;
+
+export const cloudflareInsightsUrls: EnvironmentConfig<string> = {
+  development: "https://static.cloudflareinsights.com",
+  production: "https://static.cloudflareinsights.com"
+} as const;

--- a/index.html
+++ b/index.html
@@ -35,6 +35,8 @@
       name="google-site-verification"
       content="Ys_-H_ECtl1NzD6phA7tRa8x1IUgtMacH5crbKZw3GY"
     />
+    <link rel="preconnect" href="__CLOUDFLARE_INSIGHTS_URL__" />
+    <link rel="preconnect" href="__AUDIO_URL__" />
     <title>__DISPLAY_NAME__</title>
   </head>
   <body>
@@ -42,7 +44,7 @@
     <script type="module" src="/src/main.tsx"></script>
     <script
       defer
-      src="https://static.cloudflareinsights.com/beacon.min.js"
+      src="__CLOUDFLARE_INSIGHTS_URL__/beacon.min.js"
       data-cf-beacon='{"token": "e51c6301a11946c3b28aa5187d08e640"}'
     ></script>
   </body>

--- a/vite-plugins/html.ts
+++ b/vite-plugins/html.ts
@@ -1,16 +1,33 @@
 import { type Plugin } from "vite";
 
 import { displayName, description, homepage } from "../package.json";
+import {
+  audioUrls,
+  cloudflareInsightsUrls,
+  type Environment
+} from "../env.config";
 
-const html = (): Plugin => ({
-  name: "html",
-  transformIndexHtml(html) {
-    return html
-      .replace(/__DISPLAY_NAME__/g, displayName)
-      .replace(/__DESCRIPTION__/g, description)
-      .replace(/__HOME_URL__/g, homepage)
-      .replace(/__SCREENSHOT_URL__/g, `${homepage}/screenshot.png`);
-  }
-});
+const html = (): Plugin => {
+  let mode: Environment = "development";
+
+  return {
+    name: "html",
+    config(_config, { mode: configMode }) {
+      mode = configMode as Environment;
+    },
+    transformIndexHtml(html) {
+      const audioUrl = audioUrls[mode];
+      const cloudflareInsightsUrl = cloudflareInsightsUrls[mode];
+
+      return html
+        .replace(/__DISPLAY_NAME__/g, displayName)
+        .replace(/__DESCRIPTION__/g, description)
+        .replace(/__HOME_URL__/g, homepage)
+        .replace(/__SCREENSHOT_URL__/g, `${homepage}/screenshot.png`)
+        .replace(/__AUDIO_URL__/g, audioUrl)
+        .replace(/__CLOUDFLARE_INSIGHTS_URL__/g, cloudflareInsightsUrl);
+    }
+  };
+};
 
 export default html;


### PR DESCRIPTION
## Summary

Refactors hardcoded URLs in `index.html` to use environment variables for better maintainability and consistency.

## Changes

- Added `cloudflareInsightsUrls` configuration to `env.config.ts`
- Updated `index.html` to use `__AUDIO_URL__` and `__CLOUDFLARE_INSIGHTS_URL__` placeholders
- Enhanced `vite-plugins/html.ts` to replace URL placeholders with environment-specific values
- HTML plugin now captures build mode to select correct environment configuration

## Benefits

- Centralizes URL configuration in `env.config.ts`
- Makes it easier to change URLs per environment
- Aligns audio URL usage with existing `VITE_AUDIO_URL` pattern
- Improves maintainability by removing hardcoded values from HTML

## Files Changed

- `env.config.ts` - Added Cloudflare Insights URL configuration
- `index.html` - Replaced hardcoded URLs with placeholders
- `vite-plugins/html.ts` - Added URL placeholder replacement logic