### PR TITLE
refactor: remove Theme barrel export and use direct imports

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -7,7 +7,7 @@ import Insights from "@/components/Insights";
 import Content from "@/components/App/Content";
 import Study from "@/components/Study";
 import Footer from "@/components/App/Footer";
-import { Toggle as ThemeToggle } from "@/components/Theme";
+import ThemeToggle from "@/components/Theme/Toggle";
 import useForceUpdate from "@/hooks/useForceUpdate";
 
 const App = () => {

--- a/src/components/Theme/index.tsx
+++ b/src/components/Theme/index.tsx
@@ -1,2 +1,0 @@
-export { default as Provider } from "@/components/Theme/Provider";
-export { default as Toggle } from "@/components/Theme/Toggle";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Toaster } from "@/components/ui/sonner";
-import { Provider as ThemeProvider } from "@/components/Theme";
+import ThemeProvider from "@/components/Theme/Provider";
 import Welcome from "@/components/Welcome";
 import App from "@/components/App";
 import QueryProvider from "@/lib/queryProvider";


### PR DESCRIPTION
## Summary

Removes the `Theme` barrel export file and updates imports to use direct paths instead.

## Changes

- Deleted `src/components/Theme/index.tsx` barrel export file
- Updated imports in `src/components/App/index.tsx` to import `ThemeToggle` directly from `@/components/Theme/Toggle`
- Updated imports in `src/main.tsx` to import `ThemeProvider` directly from `@/components/Theme/Provider`

## Benefits

- Better tree-shaking support
- Avoids potential circular dependency issues
- More explicit import paths improve code clarity