### PR TITLE
fix: add vite-ignore to Cloudflare Insights script

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
       defer
       src="__CLOUDFLARE_INSIGHTS_URL__/beacon.min.js"
       data-cf-beacon='{"token": "e51c6301a11946c3b28aa5187d08e640"}'
+      vite-ignore
     ></script>
   </body>
 </html>


### PR DESCRIPTION
Adds the `vite-ignore` attribute to the Cloudflare Insights beacon script to prevent Vite from processing it during build. This ensures the external script loads correctly without being transformed by Vite's build process.