### PR TITLE
feat: add export/import for study progress data

### DIFF
--- a/src/components/Insights/DataActions.tsx
+++ b/src/components/Insights/DataActions.tsx
@@ -1,0 +1,118 @@
+import { useRef, useState } from "react";
+import { DownloadIcon, UploadIcon, AlertTriangleIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import type { Study } from "@/lib/types";
+import { downloadStudies, readStudiesFile } from "@/lib/studyDataUtils";
+import { formatNumber } from "@/lib/utils";
+
+const DataActions = ({
+  studies,
+  onImport
+}: {
+  studies: Study[];
+  onImport: (studies: Study[]) => void;
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pendingImport, setPendingImport] = useState<Study[] | null>(null);
+
+  const handleExport = () => {
+    if (studies.length === 0) {
+      toast.error("No study data to export");
+      return;
+    }
+    downloadStudies(studies);
+    toast.success(`Exported ${formatNumber(studies.length)} studies`);
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const imported = await readStudiesFile(file);
+      setPendingImport(imported);
+    } catch {
+      toast.error("Invalid backup file");
+    }
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const confirmImport = () => {
+    if (pendingImport) {
+      onImport(pendingImport);
+      toast.success(`Imported ${formatNumber(pendingImport.length)} studies`);
+      setPendingImport(null);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex-1"
+          onClick={handleExport}
+        >
+          <DownloadIcon />
+          Export
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex-1"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <UploadIcon />
+          Import
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+      </div>
+      <Dialog
+        open={pendingImport !== null}
+        onOpenChange={(open) => !open && setPendingImport(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import study data</DialogTitle>
+            <DialogDescription>
+              This will replace your current study progress.
+            </DialogDescription>
+          </DialogHeader>
+          <Alert>
+            <AlertTriangleIcon />
+            <AlertTitle>Replace existing data</AlertTitle>
+            <AlertDescription>
+              Importing will replace your current {formatNumber(studies.length)}{" "}
+              studies with {formatNumber(pendingImport?.length ?? 0)} studies
+              from the backup file.
+            </AlertDescription>
+          </Alert>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingImport(null)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmImport}>Import</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default DataActions;

--- a/src/components/Insights/Tabs/Panels/Statistics.tsx
+++ b/src/components/Insights/Tabs/Panels/Statistics.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/empty";
 import { Badge } from "@/components/ui/badge";
 import LetsStudy from "@/components/LetsStudy";
+import DataActions from "@/components/Insights/DataActions";
 import type { Study } from "@/lib/types";
 import { formatNumber } from "@/lib/utils";
 
@@ -19,12 +20,14 @@ const Statistics = ({
   learning,
   mastered,
   studies,
+  onImport,
   ...props
 }: Omit<ComponentProps<typeof TabsContent>, "value"> & {
   due: Study[];
   learning: Study[];
   mastered: Study[];
   studies: Study[];
+  onImport: (studies: Study[]) => void;
 }) => {
   const stats = [
     {
@@ -75,29 +78,32 @@ const Statistics = ({
           </EmptyContent>
         </Empty>
       ) : (
-        <div className="grid grid-cols-2 gap-3">
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="text-center space-y-2 border rounded-lg p-3"
-            >
-              <Badge
-                variant={stat.variant}
-                className="flex items-center justify-center gap-2 w-full py-3"
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            {stats.map((stat) => (
+              <div
+                key={stat.label}
+                className="text-center space-y-2 border rounded-lg p-3"
               >
-                <stat.icon className="size-5!" />
-                <span className="font-bold text-xl">
-                  {formatNumber(stat.value)}
-                </span>
-              </Badge>
-              <div>
-                <p className="text-sm font-medium">{stat.label}</p>
-                <p className="text-xs text-muted-foreground">
-                  {stat.description}
-                </p>
+                <Badge
+                  variant={stat.variant}
+                  className="flex items-center justify-center gap-2 w-full py-3"
+                >
+                  <stat.icon className="size-5!" />
+                  <span className="font-bold text-xl">
+                    {formatNumber(stat.value)}
+                  </span>
+                </Badge>
+                <div>
+                  <p className="text-sm font-medium">{stat.label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {stat.description}
+                  </p>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
+          <DataActions studies={studies} onImport={onImport} />
         </div>
       )}
     </TabsContent>

--- a/src/components/Insights/Tabs/Panels/index.tsx
+++ b/src/components/Insights/Tabs/Panels/index.tsx
@@ -10,6 +10,7 @@ const Panels = ({
   due,
   learning,
   mastered,
+  onImport,
   className,
   ...props
 }: ComponentProps<"div"> & {
@@ -17,6 +18,7 @@ const Panels = ({
   learning: Study[];
   mastered: Study[];
   studies: Study[];
+  onImport: (studies: Study[]) => void;
 }) => (
   <div className={cn("overflow-auto", className)} {...props}>
     <Statistics
@@ -24,6 +26,7 @@ const Panels = ({
       learning={learning}
       mastered={mastered}
       studies={studies}
+      onImport={onImport}
     />
     <Learning due={due} learning={learning} />
     <Mastered mastered={mastered} />

--- a/src/components/Insights/Tabs/index.tsx
+++ b/src/components/Insights/Tabs/index.tsx
@@ -9,11 +9,13 @@ import { getLearning, getMastered } from "@/lib/studyUtils";
 const Tabs = ({
   studies,
   due,
+  onImport,
   className,
   ...props
 }: ComponentProps<typeof TabsComponent> & {
   studies: Study[];
   due: Study[];
+  onImport: (studies: Study[]) => void;
 }) => {
   const learning = getLearning(studies);
   const mastered = getMastered(studies);
@@ -30,6 +32,7 @@ const Tabs = ({
         due={due}
         learning={learning}
         mastered={mastered}
+        onImport={onImport}
       />
     </TabsComponent>
   );

--- a/src/components/Insights/index.tsx
+++ b/src/components/Insights/index.tsx
@@ -4,13 +4,13 @@ import { getDue } from "@/lib/studyUtils";
 import useStudiesStorage from "@/hooks/useStudiesStorage";
 
 const Insights = () => {
-  const { studies } = useStudiesStorage();
+  const { studies, replace } = useStudiesStorage();
 
   const due = getDue(studies);
 
   return (
     <Drawer due={due}>
-      <Tabs studies={studies} due={due} />
+      <Tabs studies={studies} due={due} onImport={replace} />
     </Drawer>
   );
 };

--- a/src/hooks/useStudiesStorage.ts
+++ b/src/hooks/useStudiesStorage.ts
@@ -32,7 +32,9 @@ const useStudiesStorage = () => {
       updateAll({ studies: prevStudies, entry, understood })
     );
 
-  return { studies, initialize, save };
+  const replace = (newStudies: Study[]) => setStudies(newStudies);
+
+  return { studies, initialize, save, replace };
 };
 
 export default useStudiesStorage;

--- a/src/lib/studyDataUtils.test.ts
+++ b/src/lib/studyDataUtils.test.ts
@@ -1,0 +1,146 @@
+import dayjs from "dayjs";
+import { describe, expect, it } from "vitest";
+import type { Entry, Study } from "./types";
+import { serializeStudies, deserializeStudies } from "./studyDataUtils";
+
+const makeEntry = ({
+  sequence,
+  speaker = "alice"
+}: {
+  sequence: string;
+  speaker?: string;
+}): Entry => ({
+  transcript: `Sentence ${sequence}`,
+  sequence,
+  speaker,
+  age: 30,
+  gender: "female",
+  accent: "US"
+});
+
+const makeStudy = ({
+  step = 1,
+  review = new Date("2025-01-15T10:30:00"),
+  incorrect = 0,
+  sequence = "001"
+}: Partial<Study & { sequence: string }> = {}): Study => ({
+  step,
+  review,
+  incorrect,
+  entry: makeEntry({ sequence })
+});
+
+describe("serializeStudies", () => {
+  it("produces valid JSON with version and exportedAt", () => {
+    const studies = [makeStudy()];
+    const json = serializeStudies(studies);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.exportedAt).toMatch(/^\d{14}$/);
+    expect(parsed.studies).toHaveLength(1);
+  });
+
+  it("serializes review dates as YYYYMMDDHHmmss strings", () => {
+    const studies = [makeStudy({ review: new Date("2025-06-15T08:30:00") })];
+    const json = serializeStudies(studies);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.studies[0].review).toMatch(/^\d{14}$/);
+  });
+
+  it("handles empty studies array", () => {
+    const json = serializeStudies([]);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.studies).toHaveLength(0);
+  });
+});
+
+describe("deserializeStudies", () => {
+  it("correctly parses valid data", () => {
+    const original = [makeStudy({ step: 3, incorrect: 2, sequence: "005" })];
+    const json = serializeStudies(original);
+    const result = deserializeStudies(json);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].step).toBe(3);
+    expect(result[0].incorrect).toBe(2);
+    expect(result[0].entry.sequence).toBe("005");
+    expect(result[0].review).toBeInstanceOf(Date);
+  });
+
+  it("throws on missing version", () => {
+    const json = JSON.stringify({ studies: [] });
+    expect(() => deserializeStudies(json)).toThrow("Invalid file format");
+  });
+
+  it("throws on wrong version", () => {
+    const json = JSON.stringify({ version: 2, studies: [] });
+    expect(() => deserializeStudies(json)).toThrow("Invalid file format");
+  });
+
+  it("throws on non-array studies", () => {
+    const json = JSON.stringify({ version: 1, studies: "not-array" });
+    expect(() => deserializeStudies(json)).toThrow("Invalid file format");
+  });
+
+  it("throws on invalid study fields", () => {
+    const json = JSON.stringify({
+      version: 1,
+      studies: [
+        {
+          step: "not-number",
+          incorrect: 0,
+          review: "20250115103000",
+          entry: {}
+        }
+      ]
+    });
+    expect(() => deserializeStudies(json)).toThrow("Invalid study data");
+  });
+
+  it("throws on missing entry", () => {
+    const json = JSON.stringify({
+      version: 1,
+      studies: [{ step: 1, incorrect: 0, review: "20250115103000" }]
+    });
+    expect(() => deserializeStudies(json)).toThrow("Invalid study data");
+  });
+
+  it("throws on missing review", () => {
+    const json = JSON.stringify({
+      version: 1,
+      studies: [{ step: 1, incorrect: 0, entry: {} }]
+    });
+    expect(() => deserializeStudies(json)).toThrow("Invalid study data");
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => deserializeStudies("not json")).toThrow();
+  });
+});
+
+describe("round-trip", () => {
+  it("serialize then deserialize produces equivalent data", () => {
+    const original = [
+      makeStudy({ step: 1, incorrect: 0, sequence: "001" }),
+      makeStudy({ step: 5, incorrect: 3, sequence: "042" })
+    ];
+    const json = serializeStudies(original);
+    const result = deserializeStudies(json);
+
+    expect(result).toHaveLength(2);
+    result.forEach((study, i) => {
+      expect(study.step).toBe(original[i].step);
+      expect(study.incorrect).toBe(original[i].incorrect);
+      expect(study.entry.sequence).toBe(original[i].entry.sequence);
+      expect(study.entry.speaker).toBe(original[i].entry.speaker);
+      expect(study.entry.transcript).toBe(original[i].entry.transcript);
+      expect(dayjs(study.review).format("YYYYMMDDHHmmss")).toBe(
+        dayjs(original[i].review).format("YYYYMMDDHHmmss")
+      );
+    });
+  });
+});

--- a/src/lib/studyDataUtils.ts
+++ b/src/lib/studyDataUtils.ts
@@ -1,0 +1,72 @@
+import dayjs from "dayjs";
+import type { Study } from "@/lib/types";
+
+interface StudyExport {
+  version: 1;
+  exportedAt: string;
+  studies: Study[];
+}
+
+type StudyKey = keyof Study;
+
+const isReviewKey = (key: string) => (key as StudyKey) === "review";
+
+export const serializeStudies = (studies: Study[]): string => {
+  const data: StudyExport = {
+    version: 1,
+    exportedAt: dayjs().format("YYYYMMDDHHmmss"),
+    studies
+  };
+  return JSON.stringify(data, (key, value) =>
+    isReviewKey(key) ? dayjs(value).format("YYYYMMDDHHmmss") : value
+  );
+};
+
+export const deserializeStudies = (json: string): Study[] => {
+  const data = JSON.parse(json);
+  if (!data || data.version !== 1 || !Array.isArray(data.studies)) {
+    throw new Error("Invalid file format");
+  }
+  return data.studies.map((s: Record<string, unknown>) => {
+    if (
+      typeof s.step !== "number" ||
+      typeof s.incorrect !== "number" ||
+      !s.entry ||
+      !s.review
+    ) {
+      throw new Error("Invalid study data");
+    }
+    return {
+      step: s.step,
+      review: dayjs(s.review as string, "YYYYMMDDHHmmss").toDate(),
+      incorrect: s.incorrect,
+      entry: s.entry
+    };
+  });
+};
+
+export const downloadStudies = (studies: Study[]) => {
+  const json = serializeStudies(studies);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `englitune-backup-${dayjs().format("YYYY-MM-DD")}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+export const readStudiesFile = (file: File): Promise<Study[]> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const studies = deserializeStudies(reader.result as string);
+        resolve(studies);
+      } catch (e) {
+        reject(e);
+      }
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsText(file);
+  });


### PR DESCRIPTION
## Summary

Closes #16

- Add export/import feature for study progress and spaced repetition data
- Export generates a versioned JSON backup file (`englitune-backup-YYYY-MM-DD.json`)
- Import validates the file format, shows a confirmation dialog before replacing data
- Toast notifications for success/error feedback

## Changes

### New files
- `src/lib/studyDataUtils.ts` — Pure functions for serialize/deserialize/download/read
- `src/lib/studyDataUtils.test.ts` — 12 tests (validation, round-trip, error cases)
- `src/components/Insights/DataActions.tsx` — Export/Import buttons with confirmation dialog

### Modified files
- `src/hooks/useStudiesStorage.ts` — Added `replace` function for import
- `src/components/Insights/index.tsx` — Thread `onImport` from storage hook
- `src/components/Insights/Tabs/index.tsx` — Pass `onImport` prop
- `src/components/Insights/Tabs/Panels/index.tsx` — Pass `onImport` prop
- `src/components/Insights/Tabs/Panels/Statistics.tsx` — Render `DataActions` in stats tab

## Test plan

- [x] All tests pass (`npm test` — 26 tests)
- [x] Build succeeds (`npm run build`)
- [x] Lint + Prettier pass (pre-commit hooks)
- [ ] Manual: Export with study data → valid JSON downloaded
- [ ] Manual: Import valid backup → confirmation dialog → data replaced
- [ ] Manual: Import invalid file → error toast shown
- [ ] Manual: Export with no data → error toast shown