### PR TITLE
feat: add calendar integration for study review reminders

### DIFF
--- a/src/components/Insights/CalendarButton.tsx
+++ b/src/components/Insights/CalendarButton.tsx
@@ -1,0 +1,29 @@
+import { CalendarPlusIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { downloadICS } from "@/lib/calendarUtils";
+import dayjs from "dayjs";
+
+const CalendarButton = ({ reviewDate }: { reviewDate: Date }) => {
+  const handleClick = () => {
+    downloadICS(reviewDate);
+    toast.success(
+      `Reminder set for ${dayjs(reviewDate).format("MMM D, h:mm A")}`
+    );
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      className="size-7"
+      title="Add review reminder to calendar"
+      aria-label="Add review reminder to calendar"
+      onClick={handleClick}
+    >
+      <CalendarPlusIcon className="size-3.5" />
+    </Button>
+  );
+};
+
+export default CalendarButton;

--- a/src/components/Insights/Item.tsx
+++ b/src/components/Insights/Item.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from "react";
 import { ClockIcon, XIcon } from "lucide-react";
+import CalendarButton from "@/components/Insights/CalendarButton";
 import {
   Item as ItemComponent,
   ItemContent,
@@ -34,6 +35,7 @@ const Item = ({
           <span>{study.incorrect}</span>
         </Badge>
       )}
+      {!isMastered(study) && <CalendarButton reviewDate={study.review} />}
     </ItemFooter>
   </ItemComponent>
 );

--- a/src/components/Insights/NextReviewReminder.tsx
+++ b/src/components/Insights/NextReviewReminder.tsx
@@ -1,0 +1,47 @@
+import { CalendarPlusIcon, ClockIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import type { Study } from "@/lib/types";
+import { downloadICS } from "@/lib/calendarUtils";
+import dayjs from "dayjs";
+import { formatTimeFromNow } from "@/lib/utils";
+import { getDue, getLearning } from "@/lib/studyUtils";
+
+const NextReviewReminder = ({ studies }: { studies: Study[] }) => {
+  const learning = getLearning(studies);
+  const due = getDue(studies);
+
+  const upcoming = learning
+    .filter((s) => !due.includes(s))
+    .sort((a, b) => dayjs(a.review).diff(b.review));
+
+  if (upcoming.length === 0 && due.length === 0) return null;
+
+  const nextReview = due.length > 0 ? new Date() : upcoming[0].review;
+
+  const handleClick = () => {
+    downloadICS(nextReview);
+    toast.success(
+      `Reminder set for ${dayjs(nextReview).format("MMM D, h:mm A")}`
+    );
+  };
+
+  return (
+    <div className="flex items-center justify-between border rounded-lg p-3">
+      <div className="flex items-center gap-2 text-sm">
+        <ClockIcon className="size-4 text-muted-foreground" />
+        <span>
+          {due.length > 0
+            ? `${due.length} item${due.length > 1 ? "s" : ""} due now`
+            : `Next review ${formatTimeFromNow(nextReview)}`}
+        </span>
+      </div>
+      <Button variant="outline" size="sm" onClick={handleClick}>
+        <CalendarPlusIcon />
+        <span className="hidden md:inline">Add to calendar</span>
+      </Button>
+    </div>
+  );
+};
+
+export default NextReviewReminder;

--- a/src/components/Insights/Tabs/Panels/Statistics.tsx
+++ b/src/components/Insights/Tabs/Panels/Statistics.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/components/ui/empty";
 import { Badge } from "@/components/ui/badge";
 import LetsStudy from "@/components/LetsStudy";
+import DataActions from "@/components/Insights/DataActions";
+import NextReviewReminder from "@/components/Insights/NextReviewReminder";
 import type { Study } from "@/lib/types";
 import { formatNumber } from "@/lib/utils";
 
@@ -19,12 +21,14 @@ const Statistics = ({
   learning,
   mastered,
   studies,
+  onImport,
   ...props
 }: Omit<ComponentProps<typeof TabsContent>, "value"> & {
   due: Study[];
   learning: Study[];
   mastered: Study[];
   studies: Study[];
+  onImport: (studies: Study[]) => void;
 }) => {
   const stats = [
     {
@@ -75,29 +79,33 @@ const Statistics = ({
           </EmptyContent>
         </Empty>
       ) : (
-        <div className="grid grid-cols-2 gap-3">
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="text-center space-y-2 border rounded-lg p-3"
-            >
-              <Badge
-                variant={stat.variant}
-                className="flex items-center justify-center gap-2 w-full py-3"
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            {stats.map((stat) => (
+              <div
+                key={stat.label}
+                className="text-center space-y-2 border rounded-lg p-3"
               >
-                <stat.icon className="size-5!" />
-                <span className="font-bold text-xl">
-                  {formatNumber(stat.value)}
-                </span>
-              </Badge>
-              <div>
-                <p className="text-sm font-medium">{stat.label}</p>
-                <p className="text-xs text-muted-foreground">
-                  {stat.description}
-                </p>
+                <Badge
+                  variant={stat.variant}
+                  className="flex items-center justify-center gap-2 w-full py-3"
+                >
+                  <stat.icon className="size-5!" />
+                  <span className="font-bold text-xl">
+                    {formatNumber(stat.value)}
+                  </span>
+                </Badge>
+                <div>
+                  <p className="text-sm font-medium">{stat.label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {stat.description}
+                  </p>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
+          <NextReviewReminder studies={studies} />
+          <DataActions studies={studies} onImport={onImport} />
         </div>
       )}
     </TabsContent>

--- a/src/lib/calendarUtils.test.ts
+++ b/src/lib/calendarUtils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  createReviewEvent,
+  generateICS,
+  formatICSDate,
+  escapeICS
+} from "@/lib/calendarUtils";
+
+describe("calendarUtils", () => {
+  const reviewDate = new Date("2025-06-15T14:30:00");
+
+  describe("formatICSDate", () => {
+    it("formats date as YYYYMMDDTHHmmss", () => {
+      expect(formatICSDate(reviewDate)).toBe("20250615T143000");
+    });
+  });
+
+  describe("escapeICS", () => {
+    it("escapes backslashes", () => {
+      expect(escapeICS("test\\value")).toBe("test\\\\value");
+    });
+
+    it("escapes semicolons", () => {
+      expect(escapeICS("test;value")).toBe("test\\;value");
+    });
+
+    it("escapes commas", () => {
+      expect(escapeICS("test,value")).toBe("test\\,value");
+    });
+
+    it("escapes newlines", () => {
+      expect(escapeICS("test\nvalue")).toBe("test\\nvalue");
+    });
+
+    it("escapes multiple special characters", () => {
+      expect(escapeICS("a\\b;c,d\ne")).toBe("a\\\\b\\;c\\,d\\ne");
+    });
+  });
+
+  describe("createReviewEvent", () => {
+    it("returns correct structure", () => {
+      const event = createReviewEvent(reviewDate);
+
+      expect(event.title).toBe("Englitune - Review your English lessons");
+      expect(event.description).toContain(
+        "Time to review your English lessons with spaced repetition!"
+      );
+      expect(event.description).toContain("https://englitune.silvioprog.dev");
+      expect(event.url).toBe("https://englitune.silvioprog.dev");
+      expect(event.start).toBe(reviewDate);
+      expect(event.durationMinutes).toBe(15);
+    });
+  });
+
+  describe("generateICS", () => {
+    const event = createReviewEvent(reviewDate);
+    const ics = generateICS(event);
+
+    it("starts with BEGIN:VCALENDAR", () => {
+      expect(ics).toMatch(/^BEGIN:VCALENDAR/);
+    });
+
+    it("ends with END:VCALENDAR", () => {
+      expect(ics).toMatch(/END:VCALENDAR$/);
+    });
+
+    it("contains VEVENT block", () => {
+      expect(ics).toContain("BEGIN:VEVENT");
+      expect(ics).toContain("END:VEVENT");
+    });
+
+    it("contains VALARM block", () => {
+      expect(ics).toContain("BEGIN:VALARM");
+      expect(ics).toContain("TRIGGER:-PT5M");
+      expect(ics).toContain("ACTION:DISPLAY");
+      expect(ics).toContain("END:VALARM");
+    });
+
+    it("contains correct DTSTART", () => {
+      expect(ics).toContain("DTSTART:20250615T143000");
+    });
+
+    it("contains correct DTEND (15 minutes later)", () => {
+      expect(ics).toContain("DTEND:20250615T144500");
+    });
+
+    it("contains VERSION and PRODID", () => {
+      expect(ics).toContain("VERSION:2.0");
+      expect(ics).toContain("PRODID:-//Englitune//Review Reminder//EN");
+    });
+
+    it("contains SUMMARY with escaped title", () => {
+      expect(ics).toContain("SUMMARY:Englitune - Review your English lessons");
+    });
+
+    it("contains URL", () => {
+      expect(ics).toContain("URL:https://englitune.silvioprog.dev");
+    });
+
+    it("uses CRLF line endings", () => {
+      expect(ics).toContain("\r\n");
+      const lines = ics.split("\r\n");
+      expect(lines.length).toBeGreaterThan(1);
+    });
+
+    it("contains UID with @englitune suffix", () => {
+      expect(ics).toMatch(/UID:.*@englitune/);
+    });
+  });
+});

--- a/src/lib/calendarUtils.ts
+++ b/src/lib/calendarUtils.ts
@@ -1,0 +1,70 @@
+import dayjs from "dayjs";
+
+export interface CalendarEvent {
+  title: string;
+  description: string;
+  url: string;
+  start: Date;
+  durationMinutes: number;
+}
+
+const APP_URL = "https://englitune.silvioprog.dev";
+
+export const formatICSDate = (date: Date): string =>
+  dayjs(date).format("YYYYMMDDTHHmmss");
+
+const generateUID = (): string =>
+  `${Date.now()}-${Math.random().toString(36).slice(2)}@englitune`;
+
+export const escapeICS = (text: string): string =>
+  text
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
+
+export const createReviewEvent = (reviewDate: Date): CalendarEvent => ({
+  title: "Englitune - Review your English lessons",
+  description: `Time to review your English lessons with spaced repetition!\n\n${APP_URL}`,
+  url: APP_URL,
+  start: reviewDate,
+  durationMinutes: 15
+});
+
+export const generateICS = (event: CalendarEvent): string => {
+  const end = dayjs(event.start).add(event.durationMinutes, "minute").toDate();
+
+  return [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Englitune//Review Reminder//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${generateUID()}`,
+    `DTSTART:${formatICSDate(event.start)}`,
+    `DTEND:${formatICSDate(end)}`,
+    `SUMMARY:${escapeICS(event.title)}`,
+    `DESCRIPTION:${escapeICS(event.description)}`,
+    `URL:${event.url}`,
+    "BEGIN:VALARM",
+    "TRIGGER:-PT5M",
+    "ACTION:DISPLAY",
+    `DESCRIPTION:${escapeICS(event.title)}`,
+    "END:VALARM",
+    "END:VEVENT",
+    "END:VCALENDAR"
+  ].join("\r\n");
+};
+
+export const downloadICS = (reviewDate: Date) => {
+  const event = createReviewEvent(reviewDate);
+  const ics = generateICS(event);
+  const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `englitune-review-${dayjs(reviewDate).format("YYYY-MM-DD")}.ics`;
+  a.click();
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
> **Depends on #17** — This PR imports `DataActions` from #17 (export/import feature). Please merge #17 first, then I'll rebase this branch so CI passes.

## Summary

Closes #15

- Generate `.ics` calendar files for review reminders (compatible with Google, Outlook, Apple, iOS, Android)
- Per-item calendar button on each study item (non-mastered only)
- "Next review" banner in Statistics tab with one-click "Add to calendar"
- 5-minute alarm reminder before the event
- Event message: "Time to review your English lessons with spaced repetition!"

## Changes

### New files
- `src/lib/calendarUtils.ts` — ICS generation (RFC 5545 compliant), download trigger
- `src/lib/calendarUtils.test.ts` — 18 tests (format, escaping, structure, VALARM)
- `src/components/Insights/CalendarButton.tsx` — Icon button per study item
- `src/components/Insights/NextReviewReminder.tsx` — Banner with next review info + calendar button

### Modified files
- `src/components/Insights/Item.tsx` — Added `CalendarButton` in footer (non-mastered items only)
- `src/components/Insights/Tabs/Panels/Statistics.tsx` — Added `NextReviewReminder` below stats grid

## Test plan

- [x] All tests pass (`npm test` — 44 tests)
- [x] Build succeeds (`npm run build`)
- [x] Lint + Prettier pass (pre-commit hooks)
- [ ] Manual: Click calendar button on study item → `.ics` file downloaded
- [ ] Manual: Import `.ics` into Google Calendar → event with alarm created
- [ ] Manual: "Add to calendar" in Statistics tab → `.ics` with next review date
- [ ] Manual: Mastered items don't show calendar button